### PR TITLE
Date static methods

### DIFF
--- a/delorean.js
+++ b/delorean.js
@@ -1,9 +1,9 @@
 /**
- * DeLorean - Flux capacitor for accurately faking time-bound 
+ * DeLorean - Flux capacitor for accurately faking time-bound
  * JavaScript unit testing, including timeouts, intervals, and dates
  *
  * version 0.1.2
- * 
+ *
  * http://michaelmonteleone.net/projects/delorean
  * http://github.com/mmonteleone/delorean
  *
@@ -12,12 +12,12 @@
  */
  (function() {
 
-    var global = this;          // capture reference to global scope     
+    var global = this;          // capture reference to global scope
     var version = '0.1.2';
-    var globalizedApi = false;  // whether or not api has been injected into global scope    
-    var callbacks = {};         // collection of scheduled functions    
+    var globalizedApi = false;  // whether or not api has been injected into global scope
+    var callbacks = {};         // collection of scheduled functions
     var advancedMs = 0;         // accumulation of total requested ms advancements
-    var elapsedMs = 0;          // accumulation of current time as of each callback    
+    var elapsedMs = 0;          // accumulation of current time as of each callback
     var funcCount = 0;          // number of scheduled functions
     var currentlyAdvancing = false;     // whether or not an advance is in motion
     var executionInterrupted = false;   // whether or not last advance was interrupted
@@ -62,6 +62,10 @@
         return shiftedDate;
     };
 
+    // Keep prototype methods over the facade class
+    ShiftedDate.parse = originalClock.Date.parse;
+    ShiftedDate.UTC = originalClock.Date.UTC;
+
     /**
      * Basic extension helper for copying properties of one object to another
      * @param {Object} dest object to receive properties
@@ -94,7 +98,7 @@
     var isNumeric = function(value) {
         return value !== null && !isNaN(value);
     };
-    
+
     /**
      * Helper function to return the effective current offset of time
      * from the perspective of executing callbacks
@@ -102,8 +106,8 @@
      */
     var effectiveOffset = function() {
         return currentlyAdvancing ? elapsedMs: advancedMs;
-    };    
-    
+    };
+
     /**
      * Advances fake time by an arbitrary quantity of milliseconds,
      * executing all scheduled callbacks that would have occurred within
@@ -111,26 +115,26 @@
      * @param {Number} ms quantity of milliseconds to advance fake clock
      */
     var advance = function(ms) {
-        // advance can optionally accept no parameters 
+        // advance can optionally accept no parameters
         // for just returning accumulated advanced offset
-        if(!!ms) {            
+        if(!!ms) {
             if (!isNumeric(ms) || ms < 0) {
                 throw ("'ms' argument must be a positive number");
             }
             // scheduled callbacks to be executed within range
-            var schedule = [];         
+            var schedule = [];
             // build an object to hold time range of this advancement
             var range = {
                 start: advancedMs,
-                end: advancedMs += ms                
+                end: advancedMs += ms
             };
-            
+
             // register an instance of a callback to occur
             // at a particular point in this advance's schedule
             var register = function(fn, at) {
                 schedule.push({
                     fn: fn,
-                    at: at                    
+                    at: at
                 });
             };
 
@@ -143,7 +147,7 @@
                 // collect applicable functions to run
                 for (var id in callbacks) {
                     var fn = callbacks[id];
-                    
+
                     // schedule all non-repeating timeouts that fall within advvanced range
                     if (!fn.repeats && fn.firstRunAt <= range.end) {
                         register(fn, fn.firstRunAt);
@@ -164,12 +168,12 @@
                     }
                 }
 
-                // sort all the scheduled callback instances to 
+                // sort all the scheduled callback instances to
                 // execute in correct browser order
                 schedule.sort(function(a, b) {
                     // ORDER BY
-                    //   [execution point] ASC, 
-                    //   [interval length] DESC, 
+                    //   [execution point] ASC,
+                    //   [interval length] DESC,
                     //   [order of addition] ASC
                     var order = a.at - b.at;
                     if (order === 0) {
@@ -179,13 +183,13 @@
                         }
                     }
                     return order;
-                });        
+                });
 
                 // run scheduled callback instances
                 var ran = [];
                 for (var i = 0; i < schedule.length; ++i) {
-                    var fn = schedule[i].fn;                    
-                    // only run callbacks that are still in master schedule, since a 
+                    var fn = schedule[i].fn;
+                    // only run callbacks that are still in master schedule, since a
                     // callback could have been cleared by a subsequent run of anther callback
                     if ( !! callbacks[fn.id]) {
                         elapsedMs = schedule[i].at;
@@ -197,22 +201,22 @@
                             fn.fn.apply(global);
                         } finally {
                             currentlyAdvancing = false;
-                            
+
                             // record this fn instance as having occurred, and thus trashable
                             ran.push(i);
 
-                            // completely trash non-repeating instance 
-                            // from ever being scheduled again 
+                            // completely trash non-repeating instance
+                            // from ever being scheduled again
                             if (!fn.repeats) {
                                 removeCallback(fn.id);
                             }
-                            
-                            // execution could have been interrupted if 
+
+                            // execution could have been interrupted if
                             // a callback had performed some scheduling of its own
                             if (executionInterrupted) {
                                 break;
                             }
-                        }                        
+                        }
                     }
                 }
                 // remove all run callback instances from schedule
@@ -220,7 +224,7 @@
                     schedule.splice(ran[i], 1);
                 }
             }
-            while (executionInterrupted);            
+            while (executionInterrupted);
         }
         return effectiveOffset();
     };
@@ -231,7 +235,7 @@
      * @param {Number} ms millisecond at which to schedule callback
      * @returns unique Number id of scheduled callback
      */
-    var addCallback = function(fn, ms, repeats) {        
+    var addCallback = function(fn, ms, repeats) {
         // if scheduled fn was old-school string of code
         // (yes, js officially allows for this)
         if (typeof(fn) == 'string') {
@@ -248,14 +252,14 @@
             lastRunAt: null,
             repeats: repeats
         };
-        
+
         // stop any currently advancing range of fns
-        // so that newly scheduled callback can be 
+        // so that newly scheduled callback can be
         // rolled into advance's schedule (if necessary)
         if (currentlyAdvancing) {
             executionInterrupted = true;
         }
-        
+
         return id;
     };
 
@@ -269,8 +273,8 @@
 
     /**
      * Gets (and optinally sets) value of whether
-     * the native timing functions 
-     * (setInterval, clearInterval, setTimeout, clearTimeout, Date) 
+     * the native timing functions
+     * (setInterval, clearInterval, setTimeout, clearTimeout, Date)
      * should be overwritten by DeLorean's fakes
      * @param {Boolean} shouldOverrideGlobal optional value, when passed, adds or removes the api from global scope
      * @returns {Boolean} true if native API is overwritten, false if not
@@ -285,7 +289,7 @@
 
     /**
      * Faked timing API
-     * These are kept in their own object to allow for easy 
+     * These are kept in their own object to allow for easy
      * extending and unextending of them from the global scope
      */
     var api = {
@@ -329,5 +333,5 @@
     extend(global.DeLorean, api);
 
     // set the initial state
-    reset();    
+    reset();
 })();

--- a/spec/delorean.specs.js
+++ b/spec/delorean.specs.js
@@ -6,7 +6,7 @@ QUnit.specify.extendAssertions({
         } catch(e) {
             ok(!true, message)
         }
-    }    
+    }
 });
 
 QUnit.specify("DeLorean", function() {
@@ -18,26 +18,26 @@ QUnit.specify("DeLorean", function() {
         setTimeout: window.setTimeout,
         clearInterval: window.clearInterval,
         clearTimeout: window.clearTimeout
-    };            
+    };
 
     describe("globalApi", function(){
-        
+
         it("should return 'false' by default", function(){
             var result = DeLorean.globalApi();
             assert(result).isFalse();
         });
-        
+
         describe("when passed 'true'", function(){
-            
+
             before(function(){
                 DeLorean.globalApi(true);
             });
-            
+
             it("should return 'true' on subsequent calls", function(){
                 var result = DeLorean.globalApi();
                 assert(result).isTrue();
             });
-            
+
             it("should inject global api", function(){
                 assert(window.Date).equals(DeLorean.Date);
                 assert(window.setInterval).equals(DeLorean.setInterval);
@@ -45,55 +45,60 @@ QUnit.specify("DeLorean", function() {
                 assert(window.clearInterval).equals(DeLorean.clearInterval);
                 assert(window.clearTimeout).equals(DeLorean.clearTimeout);
             });
-            
+
+            it("should keep Date prototype methods", function(){
+                assert(Date.parse).isDefined();
+                assert(Date.UTC).isDefined();
+            });
+
             it("should not inject 'globalApi', 'reset', or 'advance'", function(){
                 assert(window.globalApi).isUndefined();
                 assert(window.reset).isNotEqualTo(DeLorean.reset);
                 assert(window.advance).isUndefined();
             });
         });
-        
+
         describe("when passed 'false'", function(){
             before(function(){
-                DeLorean.globalApi(false);                
+                DeLorean.globalApi(false);
             });
-            
+
             it("should return 'false' on subsequent calls", function(){
                 var result = DeLorean.globalApi();
                 assert(result).isFalse();
             });
-            
+
             it("should reset global api to default value", function(){
                 assert(window.Date).equals(original.Date);
                 assert(window.setInterval).equals(original.setInterval);
                 assert(window.setTimeout).equals(original.setTimeout);
                 assert(window.clearInterval).equals(original.clearInterval);
-                assert(window.clearTimeout).equals(original.clearTimeout);                                
+                assert(window.clearTimeout).equals(original.clearTimeout);
             });
-            
+
             it("should remove injected api if previously injected", function(){
                 // first inject the api and make sure it injected
                 DeLorean.globalApi(true);
                 assert(window.Date).equals(DeLorean.Date);
                 assert(window.Date).isNotEqualTo(original.Date);
-                
+
                 // then remove and make sure fully removed
                 DeLorean.globalApi(false);
                 assert(window.Date).equals(original.Date);
                 assert(window.setInterval).equals(original.setInterval);
                 assert(window.setTimeout).equals(original.setTimeout);
                 assert(window.clearInterval).equals(original.clearInterval);
-                assert(window.clearTimeout).equals(original.clearTimeout);                                                
+                assert(window.clearTimeout).equals(original.clearTimeout);
             });
         });
     });
-    
+
     describe("setTimeout", function(){
-        
+
         after(function(){
-            DeLorean.reset();            
+            DeLorean.reset();
         });
-        
+
         describe("exceptional situations", function(){
             it("should throw exception when passed no params", function(){
                 assert(function(){
@@ -101,14 +106,14 @@ QUnit.specify("DeLorean", function() {
                 }).throwsException("Function setTimeout requires at least 1 parameter");
             });
             it("should throw exception when passed just ms", function(){
-                assert(function(){                    
+                assert(function(){
                     DeLorean.setTimeout(45);
                 }).throwsException("useless setTimeout call (missing quotes around argument?)")
             });
             it("should schedule fn at 0 ms when passed just fn", function(){
                 var count = 0;
                 DeLorean.setTimeout(function(){
-                    count++;                                        
+                    count++;
                 });
                 DeLorean.advance(5);
                 assert(count).equals(1);
@@ -126,75 +131,75 @@ QUnit.specify("DeLorean", function() {
                     count++;
                 }, 5);
                 DeLorean.advance(4);
-                assert(count).equals(0);                              
+                assert(count).equals(0);
             });
             it("should run fn once when advanced to exactly the time", function(){
                 var count = 0;
                 DeLorean.setTimeout(function(){
-                    count++;                    
+                    count++;
                 }, 5);
                 DeLorean.advance(5);
-                assert(count).equals(1);                
+                assert(count).equals(1);
             });
             it("should have run fn once when advanced to time and a half", function(){
                 var count = 0;
                 DeLorean.setTimeout(function(){
-                    count++;                    
+                    count++;
                 }, 5);
                 DeLorean.advance(8);
-                assert(count).equals(1);                
+                assert(count).equals(1);
             });
             it("should only have run fn once when advanced three times the time", function(){
                 var count = 0;
                 DeLorean.setTimeout(function(){
-                    count++;                    
+                    count++;
                 }, 5);
                 DeLorean.advance(15);
-                assert(count).equals(1);                
+                assert(count).equals(1);
             });
         });
         describe("when passed a string instead of fn", function(){
             it("should schedule an evaling of fn", function(){
-                // using a globally-scoped variable since 
+                // using a globally-scoped variable since
                 // eval-created functions don't have access to local scope
                 window.windowedCount = 0;
                 DeLorean.setTimeout("window.windowedCount++", 5);
                 DeLorean.advance(15);
-                assert(window.windowedCount).equals(1);                
+                assert(window.windowedCount).equals(1);
             });
-        });          
+        });
     });
-    
+
     describe("setInterval", function(){
         after(function(){
-            DeLorean.reset();            
+            DeLorean.reset();
         });
-        
+
         describe("exceptional situations", function(){
             it("should throw exception when passed no params", function(){
                 assert(function(){
-                    DeLorean.setInterval();                                        
+                    DeLorean.setInterval();
                 }).throwsException("Function setInterval requires at least 1 parameter")
             });
             it("should throw exception when passed just ms", function(){
                 assert(function(){
-                    DeLorean.setInterval(45);                                        
-                }).throwsException("useless setTimeout call (missing quotes around argument?)")                
+                    DeLorean.setInterval(45);
+                }).throwsException("useless setTimeout call (missing quotes around argument?)")
             });
             it("should behave like setTimeout with 0 ms when passed just fn", function(){
                 var count = 0;
                 DeLorean.setInterval(function(){
-                    count++;                                        
+                    count++;
                 });
                 DeLorean.advance(5);
-                assert(count).equals(1);                                
+                assert(count).equals(1);
             });
         });
         describe("when passed a fn and time", function(){
             it("should return an interval id", function(){
                 var intervalId = null;
                 intervalId = DeLorean.setInterval(function(){}, 5);
-                assert(intervalId).isNotNull();                
+                assert(intervalId).isNotNull();
             });
             it("should not have run fn when advanced to before the time", function(){
                 var count = 0;
@@ -202,7 +207,7 @@ QUnit.specify("DeLorean", function() {
                     count++;
                 }, 5);
                 DeLorean.advance(4);
-                assert(count).equals(0);                
+                assert(count).equals(0);
             });
             it("should have run fn once when advanced to exactly the time", function(){
                 var count = 0;
@@ -210,7 +215,7 @@ QUnit.specify("DeLorean", function() {
                     count++;
                 }, 5);
                 DeLorean.advance(5);
-                assert(count).equals(1);                
+                assert(count).equals(1);
             });
             it("should have run fn once when advanced to time and a half", function(){
                 var count = 0;
@@ -218,7 +223,7 @@ QUnit.specify("DeLorean", function() {
                     count++;
                 }, 5);
                 DeLorean.advance(5);
-                assert(count).equals(1);                                
+                assert(count).equals(1);
             });
             it("should have run fn thrice when advanced to exactly three times", function(){
                 var count = 0;
@@ -237,29 +242,29 @@ QUnit.specify("DeLorean", function() {
                         DeLorean.setInterval(function(){
                             runs.push('c');
                             DeLorean.setTimeout(function(){
-                                runs.push('d');            
+                                runs.push('d');
                             }, 1);
                         }, 2);
                     }, 3);
                 }, 5);
                 DeLorean.advance(15);
                 assert(runs).isSameAs(['a','b','c','d','c','d','c','d']);
-            });       
+            });
             it("should allow for setting of intervals within intervals", function(){
                 var runs = [];
                 DeLorean.setInterval(function(){
                     runs.push('a');
                     DeLorean.setInterval(function(){
-                        runs.push('b');                                                                        
-                    }, 3);                    
+                        runs.push('b');
+                    }, 3);
                 }, 5);
                 DeLorean.advance(20);
                 assert(runs).isSameAs(['a','b','a','b','b','b','a','b','b','b','b','a','b']);
-            });   
+            });
         });
         describe("when passed a string instead of fn", function(){
             it("should schedule an evaling of fn", function(){
-                // using a globally-scoped variable since 
+                // using a globally-scoped variable since
                 // eval-created functions don't have access to local scope
                 window.windowedCount = 0;
                 DeLorean.setInterval("window.windowedCount++", 5);
@@ -268,57 +273,57 @@ QUnit.specify("DeLorean", function() {
             });
         });
     });
-    
+
     describe("clearTimeout", function(){
         after(function(){
-            DeLorean.reset();           
+            DeLorean.reset();
         });
-        
+
         it("should not throw exception when passed no key", function(){
             assert(function(){
-                DeLorean.clearTimeout();                
+                DeLorean.clearTimeout();
             }).doesNotThrowException();
         });
         it("should not run when advanced past fn when passed a valid key", function(){
             var count = 0;
             var intervalId = DeLorean.setTimeout(function(){
-                count++;                
+                count++;
             }, 5);
             DeLorean.clearTimeout(intervalId);
             DeLorean.advance(15);
             assert(count).equals(0);
         });
     });
-    
+
     describe("clearInterval", function(){
        after(function(){
-           DeLorean.reset();           
+           DeLorean.reset();
        });
-       
+
        it("should not throw exception when passed no key", function(){
            assert(function(){
-               DeLorean.clearTimeout();                
-           }).doesNotThrowException();           
+               DeLorean.clearTimeout();
+           }).doesNotThrowException();
        });
        it("should not run when advanced past fn multiple times when passed a valid key", function(){
            var count = 0;
            var intervalId = DeLorean.setInterval(function(){
-               count++;                
+               count++;
            }, 5);
            DeLorean.clearInterval(intervalId);
            DeLorean.advance(15);
-           assert(count).equals(0);           
+           assert(count).equals(0);
        });
        it("should not continue to run an interval which clears itself", function(){
            var count = 0;
            var intervalId = DeLorean.setInterval(function(){
                count++;
                if(count === 4) {
-                   DeLorean.clearInterval(intervalId);                   
+                   DeLorean.clearInterval(intervalId);
                }
-           }, 5);      
+           }, 5);
            DeLorean.advance(100);
-           assert(count).equals(4);     
+           assert(count).equals(4);
        });
        it("should properly clear intervals when cleared from within a nested interval", function(){
            var runs = [];
@@ -328,7 +333,7 @@ QUnit.specify("DeLorean", function() {
                runs.push('a');
                outerCount++;
                var innerInterval = DeLorean.setInterval(function(){
-                   runs.push('b');                                      
+                   runs.push('b');
                    innerCount++;
                    if(innerCount === 4) {
                        DeLorean.clearInterval(outerInterval);
@@ -339,12 +344,12 @@ QUnit.specify("DeLorean", function() {
            assert(runs).isSameAs(['a','b','a','b','b','b']);
        });
     });
-    
+
     describe("advance", function(){
         after(function(){
-            DeLorean.reset();           
+            DeLorean.reset();
         });
-        
+
         it("should throw exception when not passed a positive ms", function(){
             assert(function(){
                 DeLorean.advance(-4);
@@ -355,12 +360,12 @@ QUnit.specify("DeLorean", function() {
         });
         it("should run scheduled fns within range when passed a ms", function(){
             var funcRunA = false;
-            var funcRunB = false;            
+            var funcRunB = false;
             DeLorean.setTimeout(function(){
                 funcRunA = true;
             }, 5);
             DeLorean.setTimeout(function(){
-                funcRunB = true;                
+                funcRunB = true;
             }, 10)
             DeLorean.advance(11);
             assert(funcRunA).isTrue();
@@ -371,13 +376,13 @@ QUnit.specify("DeLorean", function() {
             var funcRunBCount = 0;
             var funcRunCCount = 0;
             DeLorean.setTimeout(function(){
-                funcRunACount++;                
+                funcRunACount++;
             }, 10);
             DeLorean.setTimeout(function(){
-                funcRunBCount++;                
+                funcRunBCount++;
             }, 12);
             DeLorean.setInterval(function(){
-                funcRunCCount++;                
+                funcRunCCount++;
             }, 5);
             DeLorean.advance(5);
             DeLorean.advance(5);
@@ -390,7 +395,7 @@ QUnit.specify("DeLorean", function() {
             var global = window;
             var scope = null;
             DeLorean.setTimeout(function(){
-                scope = this;                
+                scope = this;
             }, 10);
             DeLorean.advance(10);
             assert(scope).equals(global);
@@ -399,7 +404,7 @@ QUnit.specify("DeLorean", function() {
             var global = window;
             var scope = null;
             DeLorean.setInterval(function(){
-                scope = this;                
+                scope = this;
             }, 10);
             DeLorean.advance(10);
             assert(scope).equals(global);
@@ -410,13 +415,13 @@ QUnit.specify("DeLorean", function() {
                 runs.push('a');
             }, 10);
             DeLorean.setInterval(function(){
-                runs.push('b');                
+                runs.push('b');
             }, 3);
             DeLorean.setTimeout(function(){
-                runs.push('c');                                
+                runs.push('c');
             }, 5);
             DeLorean.setInterval(function(){
-                runs.push('d');                
+                runs.push('d');
             }, 7);
             DeLorean.advance(15);
             DeLorean.advance(7);
@@ -426,8 +431,8 @@ QUnit.specify("DeLorean", function() {
             it("should first run fns on longer intervals before those on shorter", function(){
                 var runs = [];
                 DeLorean.setInterval(function(){
-                    runs.push('a');                    
-                }, 7);                
+                    runs.push('a');
+                }, 7);
                 DeLorean.setInterval(function(){
                     runs.push('b');
                 }, 21);
@@ -437,8 +442,8 @@ QUnit.specify("DeLorean", function() {
             it("should first run fns on longer intervals before those on shorter including timeouts", function(){
                 var runs = [];
                 DeLorean.setInterval(function(){
-                    runs.push('a');                    
-                }, 7);                
+                    runs.push('a');
+                }, 7);
                 DeLorean.setTimeout(function(){
                     runs.push('b');
                 }, 21);
@@ -466,13 +471,13 @@ QUnit.specify("DeLorean", function() {
         });
         it("should return accumulation of elapsed ms", function() {
             DeLorean.advance(10);
-            assert(DeLorean.advance()).equals(10);                        
+            assert(DeLorean.advance()).equals(10);
             DeLorean.advance(3);
             assert(DeLorean.advance()).equals(13);
             DeLorean.advance(12);
             assert(DeLorean.advance()).equals(25);
         });
-        
+
         it("should return proper accumulation of elapsed ms, even within intervaled callbacks", function(){
             var calls = [];
             DeLorean.setInterval(function(){
@@ -483,30 +488,30 @@ QUnit.specify("DeLorean", function() {
             }, 5);
             DeLorean.advance(20);
             assert(calls).isSameAs([5,8,10,13,15,18,20]);
-        });        
+        });
         it("should not advance when not passed ms, but also should still return accumulation", function(){
             // first advance to 15
             DeLorean.advance(15);
-            var resultOfFirstTry = DeLorean.advance();            
+            var resultOfFirstTry = DeLorean.advance();
             var resultOfSecondTry = DeLorean.advance();
-            assert(resultOfFirstTry).equals(15);            
-            assert(resultOfSecondTry).equals(15);            
+            assert(resultOfFirstTry).equals(15);
+            assert(resultOfSecondTry).equals(15);
         });
     });
-    
+
     describe("reset", function(){
         after(function(){
-            DeLorean.reset();           
+            DeLorean.reset();
         });
-        
+
         it("should not have called fns when fns scheduled, reset called, and advanced", function(){
             var funcRunA = false;
-            var funcRunB = false;            
+            var funcRunB = false;
             DeLorean.setTimeout(function(){
                 funcRunA = true;
             }, 5);
             DeLorean.setTimeout(function(){
-                funcRunB = true;                
+                funcRunB = true;
             }, 10)
             DeLorean.reset();
             DeLorean.advance(11);
@@ -515,25 +520,25 @@ QUnit.specify("DeLorean", function() {
         });
         it("should reset offset so that new Dates are equal to real Date", function(){
             var originalDate = new original.Date();
-            
+
             DeLorean.advance(200);
             var mockDateAdvance = new DeLorean.Date();
             var difference = mockDateAdvance - originalDate;
-            
+
             DeLorean.reset();
             var mockDateAfterReset = new DeLorean.Date();
             var differenceReset = mockDateAfterReset - originalDate;
-            
+
             assert(difference).equals(200);
             assert(differenceReset).equals(0);
         });
     });
-    
+
     describe("Date", function(){
         after(function(){
-            DeLorean.reset();           
+            DeLorean.reset();
         });
-        
+
         it("should behave same as native Date when passed one argument", function(){
             var originalDate = new original.Date(699769876987);
             var mockDate = new DeLorean.Date(699769876987);
@@ -548,37 +553,37 @@ QUnit.specify("DeLorean", function() {
             DeLorean.advance(200);
             var advancedMockDate = new DeLorean.Date(1995,11,17);
             assert(originalDate).isSameAs(mockDate);
-            assert(originalDate).isSameAs(advancedMockDate);            
+            assert(originalDate).isSameAs(advancedMockDate);
         });
         describe("when passed no argument", function(){
             it("should create Date with value same as native Date when not yet advanced", function(){
                 var originalDate = new original.Date();
                 var mockDate = new DeLorean.Date();
                 var difference = mockDate - originalDate;
-                assert(difference).equals(0);                
+                assert(difference).equals(0);
             });
             it("should create Date offset by the advanced ms when advanced once", function(){
                 var originalDate = new original.Date();
                 DeLorean.advance(200);
                 var mockDate = new DeLorean.Date();
                 var difference = mockDate - originalDate;
-                assert(difference).equals(200);                
+                assert(difference).equals(200);
             });
             it("should create Dates offset by accumulation of advancements when advanced multiple times", function(){
                 var originalDate = new original.Date();
-                
+
                 DeLorean.advance(200);
                 var mockDateOneAdvance = new DeLorean.Date();
                 var differenceOneAdvance = mockDateOneAdvance - originalDate;
-                
+
                 DeLorean.advance(200);
                 var mockDateTwoAdvance = new DeLorean.Date();
                 var differenceTwoAdvance = mockDateTwoAdvance - originalDate;
-                
+
                 DeLorean.advance(200);
                 var mockDateThreeAdvance = new DeLorean.Date();
                 var differenceThreeAdvance = mockDateThreeAdvance - originalDate;
-                
+
                 assert(differenceOneAdvance).equals(200);
                 assert(differenceTwoAdvance).equals(400);
                 assert(differenceThreeAdvance).equals(600);


### PR DESCRIPTION
I've added carrying of Date static methods (turns out I couldn't use Date.parse() when using DeLorean.globalApi(true) for testing a library).

The whitespace deletions come as courtesy of my text editor =|
